### PR TITLE
Clean Moon config

### DIFF
--- a/.moon/tasks/tag-chromatic.yml
+++ b/.moon/tasks/tag-chromatic.yml
@@ -4,17 +4,11 @@ fileGroups:
 
 tasks:
   storybook:
-    command:
-      - storybook
-      - dev
-      - --port=6006
+    command: storybook dev --port=6006
     local: true
     platform: node
   storybook-build:
-    command:
-      - storybook
-      - build
-      - --output-dir=storybook-static
+    command: storybook build --output-dir=storybook-static
     inputs:
       - "@group(frontend)"
       - "@group(storybookConfig)"
@@ -22,10 +16,7 @@ tasks:
       - "storybook-static/"
     platform: node
   chromatic:
-    command:
-      - chromatic
-      - --storybook-build-dir=storybook-static
-      - --exit-zero-on-changes
+    command: chromatic --storybook-build-dir=storybook-static --exit-zero-on-changes
     inputs:
       - "storybook-static/**/*"
       - "*.*"

--- a/.moon/tasks/tag-eslint.yml
+++ b/.moon/tasks/tag-eslint.yml
@@ -1,8 +1,6 @@
 tasks:
   lint:
-    command:
-      - eslint
-      - .
+    command: eslint .
     platform: node
     inputs:
       # Config files anywhere within the project

--- a/.moon/tasks/tag-prettier.yml
+++ b/.moon/tasks/tag-prettier.yml
@@ -1,15 +1,7 @@
 tasks:
   prettier:
-    extends: prettier-check
-    args:
-      - --write
-    options:
-      mergeArgs: prepend
+    command: prettier --write --check .
     local: true
   prettier-check:
-    command:
-      - prettier
-    args:
-      - --check
-      - .
+    command: prettier --check .
     platform: node

--- a/.moon/tasks/tag-typescript.yml
+++ b/.moon/tasks/tag-typescript.yml
@@ -1,9 +1,7 @@
 tasks:
   typecheck:
-    command:
-      - tsc
-      - --noEmit
+    command: tsc --noEmit
     platform: node
     inputs:
       - "*.{ts,cts,mts,tsx,mtsx,js,cjs,mjs,json}"
-      - "src/**/*.{ts,cts,mts,tsx,mtsx,js,cjs,mjs,json}"
+      - "{src,api}/**/*.{ts,cts,mts,tsx,mtsx,js,cjs,mjs,json}"

--- a/.moon/tasks/tag-vercel.yml
+++ b/.moon/tasks/tag-vercel.yml
@@ -1,4 +1,5 @@
 tasks:
+  # Allows running `vercel` in a project context, using for CI scripts.
   vercel:
     command:
       - vercel

--- a/README.md
+++ b/README.md
@@ -8,11 +8,6 @@ Install [proto](https://moonrepo.dev/proto):
 
 ```sh
 curl -fsSL https://moonrepo.dev/install/proto.sh | bash
-```
-
-Install other tools used in the workspace:
-
-```sh
 proto use
 ```
 

--- a/moon.yml
+++ b/moon.yml
@@ -16,24 +16,14 @@ tasks:
     args:
       - "'!./projects/**/*'"
   doctor:
-    command:
-      - yarn
-      - doctor
-      - .
-    platform: node
+    command: yarn doctor .
     inputs:
       - "@group(yarnConfig)"
   node-version:
-    command:
-      - node
-      - "--version"
-    platform: node
+    command: node --version
     local: true
   yarn-constraints:
-    command:
-      - yarn
-      - constraints
-    platform: node
+    command: yarn constraints
     inputs:
       - "@group(yarnConfig)"
 

--- a/projects/api/moon.yml
+++ b/projects/api/moon.yml
@@ -1,38 +1,24 @@
 tasks:
   dev:
     command: vercel dev
+    platform: node
     local: true
   test:
-    command:
-      - node
-      - --test
-    args:
-      - --import
-      - tsx
-      - "**/*.test.ts"
-    platform: node
+    command: node --test --import tsx '**/*.test.ts'
   test-watch:
-    extends: test
-    args:
-      - --watch
-    options:
-      mergeArgs: prepend
+    command: node --test --watch --import tsx '**/*.test.ts'
     local: true
   upload-sentry-source-maps:
-    command:
-      - npx
-      - sentry-expo-upload-sourcemaps
-      - dist
-    platform: node
+    command: npx sentry-expo-upload-sourcemaps dist
     local: true
   dbGenerate:
-    command: yarn drizzle-kit generate
-    local: true
+    command: drizzle-kit generate
     platform: node
+    local: true
   dbMigrate:
-    command: node --import tsx ./src/bin/migrate.ts
-    local: true
+    command: tsx ./src/bin/migrate.ts
     platform: node
+    local: true
     options:
       cache: false
       envFile: .env.local

--- a/projects/emails/moon.yml
+++ b/projects/emails/moon.yml
@@ -5,22 +5,16 @@ fileGroups:
 
 tasks:
   dev:
-    command:
-      - email
-      - dev
+    command: email dev
     platform: node
     local: true
   build:
-    command:
-      - email
-      - build
+    command: email build
     inputs:
       - "@group(emails)"
     platform: node
   start:
-    command:
-      - email
-      - start
+    command: email start
     deps:
       - build
     platform: node

--- a/projects/frontend/moon.yml
+++ b/projects/frontend/moon.yml
@@ -1,8 +1,6 @@
 tasks:
   dev:
-    command:
-      - expo
-      - start
+    command: expo start
     platform: node
     local: true
   dev-android:
@@ -18,21 +16,12 @@ tasks:
     args:
       - --web
   expo-doctor:
-    command:
-      - npx
-      - "--yes"
-      - expo-doctor
-    platform: node
+    command: npx --yes expo-doctor
   eas:
-    command:
-      - npx
-      - "--yes"
-      - eas-cli@latest
+    command: npx --yes eas-cli@latest
     local: true
   export:
-    command:
-      - expo
-      - export
+    command: expo export
     platform: node
     inputs:
       - "assets/**/*"
@@ -43,40 +32,20 @@ tasks:
       - "dist/"
   expo-generate-types:
     # The recommended command from https://docs.expo.dev/router/reference/typed-routes/#type-generation
-    command:
-      - expo
-      - customize
-      - tsconfig.json
+    command: expo customize tsconfig.json
     platform: node
     options:
       cache: false
   test:
-    command:
-      - node
-      - --test
-    args:
-      - --import
-      - tsx
-      - "**/*.test.ts"
-    platform: node
+    command: node --test --import tsx "**/*.test.ts"
   test-watch:
-    extends: test
-    args:
-      - --watch
-    options:
-      mergeArgs: prepend
+    command: node --test --watch --import tsx "**/*.test.ts"
     local: true
   typecheck:
     deps:
       - expo-generate-types
-    options:
-      mergeDeps: append
   upload-sentry-source-maps:
-    command:
-      - npx
-      - sentry-expo-upload-sourcemaps
-      - dist
-    platform: node
+    command: npx sentry-expo-upload-sourcemaps dist
     local: true
 
 tags:

--- a/projects/static/moon.yml
+++ b/projects/static/moon.yml
@@ -1,8 +1,6 @@
 tasks:
   generate-speech:
-    command:
-      - ts-node-script
-      - src/bin/generate-speech.ts
+    command: ts-node-script src/bin/generate-speech.ts
     platform: node
     env:
       # Hide the warning about fs/promises glob


### PR DESCRIPTION
- `platform: node` is only needed when the executable is something found in `./node_modules/.bin` and should be run with Node, rather than something on system PATH.
- `command:` string is much more readable than list syntax
- Using `extends:` hurts readability, in most cases it's clearer to just inline things.