### PR TITLE
Run all tests in daily CI

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -12,8 +12,9 @@ jobs:
     steps:
       - name: 🏗 Clone repo
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        # Intentionally omit `fetch-depth: 0` to force all targets to be run
+        # instead of some being skipped due to `moon run <…> --affected`
+        # behavior.
 
       - name: 📦 Install dependencies
         uses: moonrepo/setup-toolchain@v0.3.1


### PR DESCRIPTION
I realised most were being skipped because moon was only running targets based on changes from the last commit.