### PR TITLE
Don't renovate @types/ beyond range

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,11 @@
       "automerge": true
     },
     {
+      "matchManagers": ["npm"],
+      "matchDepPatterns": ["@types/*"],
+      "rangeStrategy": "in-range-only"
+    },
+    {
       "matchDepNames": ["moonrepo/moon"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true


### PR DESCRIPTION
@types/ version ranges are already kept correct with respect to their sibling package via Yarn constraints, so renovate should not try to bump them outside the range.

This should fix @types/react being bumped