### PR TITLE
Fix neon branch name to not include run_attempt

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
       #
       # The run attempt is only included for re-runs to keep the branch name
       # slightly shorter and cleaner when there is no re-run.
-      NEON_BRANCH_NAME: github_test_pr_${{ github.run_id }}${{ github.run_attempt == '1' && '' || format(':{0}', github.run_attempt) }}
+      NEON_BRANCH_NAME: github_test_pr_${{ github.run_id }}${{ github.run_attempt != '1' && format(':{0}', github.run_attempt) || '' }}
       NEON_DATABASE_NAME: hao
     steps:
       - name: 🏗 Clone repo


### PR DESCRIPTION
I think because `''` was falsy using the `&&` and `||` as a ternary doesn't work so needed to be flipped so that `''` was always last.