### PR TITLE
Fix npx scripts

### DIFF
--- a/.github/workflows/expo-eas-build.yml
+++ b/.github/workflows/expo-eas-build.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: ./.github/actions/setup-tools
 
       - name: 🚀 Build app
-        run: npx eas-cli@10.1.1 build --profile=${{ inputs.profile }} --platform=${{ inputs.platform }} --non-interactive
+        run: npx -y eas-cli@10.1.1 build --profile=${{ inputs.profile }} --platform=${{ inputs.platform }} --non-interactive
         working-directory: projects/app
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}

--- a/.moon/tasks/tag-prettier.yml
+++ b/.moon/tasks/tag-prettier.yml
@@ -1,6 +1,6 @@
 tasks:
   prettier:
-    command: npx prettier@3.3.2 --write --check .
+    command: npx -y prettier@3.3.2 --write --check .
     local: true
   prettier-check:
-    command: npx prettier@3.3.2 --check .
+    command: npx -y prettier@3.3.2 --check .

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@types/semver": "7.5.x",
     "@yarnpkg/doctor": "^4.0.2",
     "@yarnpkg/types": "^4.0.0",
-    "prettier": "^3.2.5",
     "semver": "^7.5.0",
     "typescript": "^5.5.2"
   },

--- a/projects/app/moon.yml
+++ b/projects/app/moon.yml
@@ -53,7 +53,7 @@ tasks:
   buildVercelExpoSentry:
     command: |
       rsync -a --delete @group(buildVercelExpoOutdir) @group(buildVercelExpoSentryOutdir) &&
-      npx @sentry/cli@2.32.1 sourcemaps inject @group(buildVercelExpoSentryOutdir)
+      npx -y @sentry/cli@2.32.1 sourcemaps inject @group(buildVercelExpoSentryOutdir)
     options:
       shell: true
     deps:
@@ -70,7 +70,7 @@ tasks:
       cache: false
 
   dbGenerate:
-    command: npx drizzle-kit@0.22.8 generate
+    command: npx -y drizzle-kit@0.22.8 generate
     local: true
 
   dbMigrate:
@@ -96,7 +96,7 @@ tasks:
       persistent: false
 
   deployEasUpdateEas:
-    command: npx eas-cli@10.1.1 update --skip-bundler --input-dir @group(buildEasUpdateOutdir) --auto --non-interactive
+    command: npx -y eas-cli@10.1.1 update --skip-bundler --input-dir @group(buildEasUpdateOutdir) --auto --non-interactive
     deps:
       - buildEasUpdate
     local: true
@@ -104,7 +104,7 @@ tasks:
       persistent: false
 
   deployEasUpdateSentry:
-    command: npx sentry-expo-upload-sourcemaps @group(buildEasUpdateOutdir)
+    command: npx -y sentry-expo-upload-sourcemaps @group(buildEasUpdateOutdir)
     deps:
       - buildEasUpdate
     local: true
@@ -124,7 +124,7 @@ tasks:
       - buildVercel
 
   deployVercelSentry:
-    command: npx @sentry/cli@2.32.1 sourcemaps upload -o haohaohow -p app @group(buildVercelOutdir)
+    command: npx -y @sentry/cli@2.32.1 sourcemaps upload -o haohaohow -p app @group(buildVercelOutdir)
     deps:
       - buildVercel
     local: true
@@ -136,7 +136,7 @@ tasks:
     local: true
 
   expoDoctor:
-    command: npx expo-doctor@1.6.1
+    command: npx -y expo-doctor@1.6.1
     options:
       # This checks the latest version of dependencies from the internet, so it
       # can't cache purely off local filesystem. It's important cache is

--- a/yarn.lock
+++ b/yarn.lock
@@ -11090,7 +11090,6 @@ __metadata:
     "@types/semver": "npm:7.5.x"
     "@yarnpkg/doctor": "npm:^4.0.2"
     "@yarnpkg/types": "npm:^4.0.0"
-    prettier: "npm:^3.2.5"
     semver: "npm:^7.5.0"
     typescript: "npm:^5.5.2"
   languageName: unknown
@@ -14494,15 +14493,6 @@ __metadata:
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
   checksum: 10c0/b00d617431e7886c520a6f498a2e14c75ec58f6d93ba48c3b639cf241b54232d90daa05d83a9e9b9fef6baa63cb7e1e4602c2372fea5bc169668401eb127d0cd
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^3.2.5":
-  version: 3.3.2
-  resolution: "prettier@npm:3.3.2"
-  bin:
-    prettier: bin/prettier.cjs
-  checksum: 10c0/39ed27d17f0238da6dd6571d63026566bd790d3d0edac57c285fbab525982060c8f1e01955fe38134ab10f0951a6076da37f015db8173c02f14bc7f0803a384c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Remove left-over prettier package.json dependency.
- Add `-y` (`--yes`) to all npx commands so they don't hang the first time you run them.