### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,10 @@ on:
   merge_group:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   app-preview:
     runs-on: ubuntu-latest
@@ -34,16 +38,15 @@ jobs:
 
       - uses: ./.github/actions/setup-tools
 
-      - run: moon run app:dbMigrate
+      - run: moon run app:dbMigrate --affected --remote
         env:
           DATABASE_URL: ${{ steps.create-neon-branch.outputs.db_url }}
 
-      - name: 🚀 Preview deployment
-        run: |
-          npx vercel@34.3.0 pull --cwd projects/app --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-          moon run app:deployVercel
+      - name: 🚀 Deploy to Vercel (preview)
+        run: moon run app:deployVercel --affected --remote
         env:
           EXPO_PUBLIC_REPLICACHE_LICENSE_KEY: ${{ secrets.EXPO_PUBLIC_REPLICACHE_LICENSE_KEY }}
+          HHH_VERCEL_PREVIEW:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
@@ -67,11 +70,10 @@ jobs:
 
       - uses: ./.github/actions/setup-tools
 
-      - name: 🚀 Preview deployment
-        run: |
-          npx vercel@34.3.0 pull --cwd projects/static --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-          moon run static:deploy
+      - name: 🚀 Deploy to Vercel (preview)
+        run: moon run static:deploy --affected --remote
         env:
+          HHH_VERCEL_PREVIEW:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
   moon-ci:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+concurrency:
+  # Ensure only one build at a time, so that DB migrations, EAS releases, Vercel
+  # deployments, all happen in sequence and results are more deterministic.
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   database:
     runs-on: ubuntu-latest
@@ -17,7 +22,7 @@ jobs:
       - uses: ./.github/actions/setup-tools
 
       - name: 🚀 Migrate database
-        run: moon run app:dbMigrate
+        run: moon run app:dbMigrate --affected --remote
         env:
           DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
 
@@ -34,14 +39,11 @@ jobs:
 
       - uses: ./.github/actions/setup-tools
 
-      - name: 🔑 Fetch Vercel secrets
-        run: npx vercel@34.3.0 pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-        working-directory: projects/app
-
-      - name: 🚀 Build and deploy
-        run: moon run app:deployVercel
+      - name: 🚀 Deploy to Vercel (production)
+        run: moon run app:deployVercel --affected --remote
         env:
           EXPO_PUBLIC_REPLICACHE_LICENSE_KEY: ${{ secrets.EXPO_PUBLIC_REPLICACHE_LICENSE_KEY }}
+          HHH_VERCEL_PROD:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
@@ -58,13 +60,10 @@ jobs:
 
       - uses: ./.github/actions/setup-tools
 
-      - name: 🔑 Fetch Vercel secrets
-        run: npx vercel@34.3.0 pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-        working-directory: projects/static
-
-      - name: 🚀 Build and deploy
-        run: moon run static:deploy
+      - name: 🚀 Deploy to Vercel (production)
+        run: moon run static:deploy --affected --remote
         env:
+          HHH_VERCEL_PROD:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
   app-eas-update:
@@ -78,9 +77,8 @@ jobs:
       - uses: ./.github/actions/setup-tools
 
       - name: 🚀 Build and deploy
-        run: moon run app:deployEasUpdate
+        run: moon run app:deployEasUpdate --affected --remote
         env:
           EXPO_PUBLIC_REPLICACHE_LICENSE_KEY: ${{ secrets.EXPO_PUBLIC_REPLICACHE_LICENSE_KEY }}
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.moon/tasks/tag-vercel.yml
+++ b/.moon/tasks/tag-vercel.yml
@@ -1,0 +1,14 @@
+tasks:
+  deploy:
+    command: |
+      npx -y vercel@34.3.0 pull --yes ${HHH_VERCEL_PREVIEW+--environment=preview} ${HHH_VERCEL_PROD+--environment=production} ${VERCEL_TOKEN:+--token=$VERCEL_TOKEN} &&
+      npx -y vercel@34.3.0 build ${HHH_VERCEL_PROD+--prod} &&
+      npx -y vercel@34.3.0 deploy --prebuilt ${HHH_VERCEL_PROD+--prod} ${VERCEL_TOKEN:+--token=$VERCEL_TOKEN}
+    inputs:
+      - $VERCEL_*
+      - $HHH_VERCEL_PREVIEW # Use to turn on "preview" mode.
+      - $HHH_VERCEL_PROD # Use to turn on "production" mode.
+    local: true
+    options:
+      persistent: false
+      shell: true

--- a/moon.yml
+++ b/moon.yml
@@ -28,7 +28,7 @@ tasks:
     inputs:
       - "@group(yarnConfig)"
   renovate-check:
-    command: npx --yes -p renovate@37.424.1 renovate-config-validator --strict
+    command: npx -y -p renovate@37.424.1 renovate-config-validator --strict
     inputs:
       - renovate.json
 

--- a/projects/app/moon.yml
+++ b/projects/app/moon.yml
@@ -13,6 +13,11 @@ fileGroups:
   buildEasUpdateOutdir:
     - dist/eas/
 
+workspace:
+  inheritedTasks:
+    rename:
+      deploy: "deployVercelVercel"
+
 tasks:
   build:
     deps:
@@ -70,6 +75,8 @@ tasks:
 
   dbMigrate:
     command: yarn tsx ./src/bin/dbMigrate.ts
+    inputs:
+      - drizzle/**/*
     local: true
     options:
       envFile: .env.local
@@ -113,17 +120,8 @@ tasks:
       persistent: false
 
   deployVercelVercel:
-    command: |
-      npx vercel@34.3.0 build --prod &&
-      npx vercel@34.3.0 deploy --prebuilt --prod --token=$VERCEL_TOKEN
-    options:
-      shell: true
-      persistent: false
-    inputs:
-      - $VERCEL_TOKEN
     deps:
       - buildVercel
-    local: true
 
   deployVercelSentry:
     command: npx @sentry/cli@2.32.1 sourcemaps upload -o haohaohow -p app @group(buildVercelOutdir)
@@ -170,3 +168,4 @@ tags:
   - eslint
   - prettier
   - typescript
+  - vercel

--- a/projects/static/moon.yml
+++ b/projects/static/moon.yml
@@ -4,16 +4,15 @@ tasks:
     env:
       # Hide the warning about fs/promises glob
       NODE_OPTIONS: --no-warnings=ExperimentalWarning
+    inputs:
+      - src/**/*
     local: true
 
   deploy:
-    command: |
-      npx vercel@34.3.0 build --prod &&
-      npx vercel@34.3.0 deploy --prebuilt --prod --token=$VERCEL_TOKEN
-    options:
-      shell: true
-    local: true
+    inputs:
+      - public/**/*
 
 tags:
   - prettier
   - typescript
+  - vercel


### PR DESCRIPTION
- Fix PR builds deploying to Vercel production (oops).
- Refactor vercel deployment moon tasks to live be in one place.
- Move `vercel pull` code into the moon task (this simplifies GH actions).
- Disable concurrency for the `main` branch `release` workflow (oops).
- Only deploy if needed (based on moon `--affected`). This should avoid hitting the Vercel deployment 24 hour limit.