### PR TITLE
Fix renovate for npx

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -49,7 +49,7 @@
         "^projects/[^/]+/[^/]+.ya?ml$"
       ],
       "matchStrings": [
-        "(npx|npm exec|yarn dlx|pnpm dlx)( -[-a-z]+?)* (?<depName>(@[a-z0-9-~][a-z0-9-._~]*\\/)?[a-z0-9-~][a-z0-9-._~]*)@(?<currentValue>[^ ]+)\\s"
+        "(npx|npm exec|yarn dlx|pnpm dlx)( -[-a-z]+?)* (?<depName>(@[a-z0-9-~][a-z0-9-._~]*\\/)?[a-z0-9-~][a-z0-9-._~]*)@(?<currentValue>[^ $]+)"
       ],
       "datasourceTemplate": "npm"
     },


### PR DESCRIPTION
The trailing `\s` in the rule was confusing it with new lines (in the case where there are no arguments to the npx command).