### PR TITLE
Fix renovate configuration for moon's node toolchain

### DIFF
--- a/.moon/toolchain.yml
+++ b/.moon/toolchain.yml
@@ -1,5 +1,5 @@
 node:
-  version: "~22.8.0"
+  version: "~22.8.0" # renovate: datasource=npm depName=node
   packageManager: "yarn"
   yarn:
     version: "4.5.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typescript": "^5.5.2"
   },
   "engines": {
-    "node": "~22.9.0"
+    "node": "~22.8.0"
   },
   "resolutions": {
     "@testing-library/user-event@npm:14.3.0": "npm:@testing-library/user-event@^14.5.0",

--- a/renovate.json
+++ b/renovate.json
@@ -3,17 +3,20 @@
   "extends": ["config:recommended"],
   "packageRules": [
     {
+      "description": "Don't update non-dev dependencies, too risky of it breaking something.",
       "matchManagers": ["npm"],
       "matchDepTypes": ["dependencies"],
       "enabled": false
     },
     {
+      "description": "Only non-major (less risky) updates for devDependencies ala tooling.",
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
+      "description": "Be conservative and wait a while after a new release to settle (often bugs are found).",
       "matchDatasources": ["npm"],
       "minimumReleaseAge": "3 days",
       "internalChecksFilter": "strict"


### PR DESCRIPTION
This should keep moon's toolchain in sync with package.json/engines