### PR TITLE
Only show the iOS Smart App Banner on the home page

### DIFF
--- a/projects/app/public/.well-known/apple-app-site-association
+++ b/projects/app/public/.well-known/apple-app-site-association
@@ -4,8 +4,11 @@
     "details": [
       {
         "appID": "9GVZK5FM29.how.haohao.hoa",
-        "paths": [
-          "/learn/*"
+        "components": [
+          {
+            "/": "/",
+            "comment": "Only prompt to open the app from the home page, it's too distracting on other pages."
+          }
         ]
       }
     ]


### PR DESCRIPTION
It was taking up too much space on other pages and caused page jank.